### PR TITLE
Fix the triple tick formatting on the mermaid example

### DIFF
--- a/doc/Adding Mermaid Diagrams.md
+++ b/doc/Adding Mermaid Diagrams.md
@@ -70,13 +70,13 @@ That's it!
 Now let's add a Flowchart using fenced code syntax:
 
 ```html
- ```mermaid
-       graph TD;
-         A-->B;
-         A-->C;
-         B-->D;
-         C-->D;
- ```
+    ```mermaid
+        graph TD;
+          A-->B;
+          A-->C;
+          B-->D;
+          C-->D;
+    ```
 ```
 
 If you see some weird whitespace and ugly background color, you can add following global styles in `Preferences...>Custom CSS` (thanks [@mmatti](https://twitter.com/mmatti)):


### PR DESCRIPTION
I didn't see any PR but I figured I could still make one. The document had a invalid markdown.
